### PR TITLE
Remove password from "user created..." dialogue

### DIFF
--- a/src/client/src/ch/specchio/gui/UserAccountDialog.java
+++ b/src/client/src/ch/specchio/gui/UserAccountDialog.java
@@ -389,7 +389,7 @@ public class UserAccountDialog extends JDialog implements ActionListener {
 				cf.addAccountConfiguration(d);
 				
 				// report success
-				String message = "User " + user.getUsername() + " created with password " + user.getPassword() + ". " +
+				String message = "User " + user.getUsername() + " created ". " +
 						"An entry for this user has been added to your configuration file.";
 				JOptionPane.showMessageDialog(
 						(Frame)getOwner(),


### PR DESCRIPTION
Remove the display of a newly created password, to only display the account name in the dialogue box. 